### PR TITLE
Fixed smoke dialogs availability when there are slow loading images and cleaned tabs mixed with spaces

### DIFF
--- a/smoke/smoke.js
+++ b/smoke/smoke.js
@@ -151,7 +151,7 @@
 				'</div>';
 	
 			if (!smoke.init){		
-				smoke.listen(window,"load", function(){
+				contentLoaded(window, function() {
 					smoke.finishbuild(e,f,box);
 				});
 			} else{


### PR DESCRIPTION
Hey,

I was testing smoke.js on a pre-prodution website and I noticed that it was taking a long time for the dialogs to be available because of a DNS problem with our pre-production CDN. This was because window.onload was being used, and that only fires after the last asset is loaded.

I decided to use a very minimal DOMContentLoaded cross-browser library made by Diego Perini (https://github.com/dperini/ContentLoaded), it's also MIT licensed, so it's compatible) to fix this problem.

This way, smoke dialogs are available as soon as the DOM is ready.

Since I put it in a self-calling lambda, the global namespace won't be polluted, and only window.smoke will be defined.

I also fixed a couple of tabs mixed with spaces indentation issues.

Hope you don't mind the usage of an external library, it's very minimal and doesn't pollute the global namespace.

Carlos
