### PR TITLE
Remove element once the dialog is closed

### DIFF
--- a/smoke/smoke.js
+++ b/smoke/smoke.js
@@ -298,6 +298,10 @@ var smoke = {
 		
 		smoke.i = 0;
 		box.innerHTML = '';
+		if ( box.parentNode ) {
+			box.parentNode.removeChild( box );
+		}
+
 	},
 
 	alert: function (e, f, g) {


### PR DESCRIPTION
I dont know if there is any reason for the boxes not to be removed once the user has closed the box. But here is a small change that removes the div once the dialog is closed. 
It is the same way that jQuery does remove() on elements

Tested in Chrome, Firefox and Safari
