### PR TITLE
Custom classname property for signal type

### DIFF
--- a/smoke.js
+++ b/smoke.js
@@ -416,17 +416,21 @@
 			});
 		},
 		
-		signal: function (e, f, g) {
+		signal: function (e, f, g, h) {
 			if (typeof g === 'undefined') {
 				g = 5000;
 			}
 			
+			if (typeof h === 'undefined') {
+				h = false;
+			}
+
 			var id = smoke.newdialog();
 			smoke.build(e, {
 				type:    'signal',
 				callback: f,
 				timeout: g,
-				params:  false,
+				params:  h,
 				newid:   id
 			});
 		},


### PR DESCRIPTION
I don't see a reason signal shouldn't have custom classname property
working, so here it is. It was a quick one and I hope I didn't miss
anything.
